### PR TITLE
fix: Address array handling and default value assignment

### DIFF
--- a/examples/shared/libcalc.hike
+++ b/examples/shared/libcalc.hike
@@ -46,3 +46,14 @@ cfunc HikeAbsDiff(a int, b int) int {
 	diff := a - b
 	return abs(diff)
 }
+
+// 2nd test for cfunc with array parameter
+// fix(emitter): handle array-type casts in emitCast (Fixes #2)#3
+cfunc CTestArr(val int) int {
+    var h [5]int
+    h[0] = val
+    h[1] = val + 1
+    var sum int = 0
+    sum = h[0] + h[1]
+    return sum
+}

--- a/pkg/lower/lower_stmt.go
+++ b/pkg/lower/lower_stmt.go
@@ -224,6 +224,9 @@ func (s *StmtLowerer) LowerAssignStmt(stmt *ast.AssignStmt) {
 					} else {
 						val = s.root.emitValueCoerce(val, targetType)
 					}
+				} else {
+					// 初期値省略時は対象型のデフォルトゼロ値（配列なら ConstZero）を取得
+					val = s.root.defaultConstValue(targetType)
 				}
 			} else if val != nil {
 				targetType = val.Type()

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -935,15 +935,10 @@ func (p *Parser) parseVarStmt() ast.Statement {
 		}
 	}
 
-	rights := make([]ast.Expression, len(idents))
-	for i := range rights {
-		rights[i] = &ast.IntegerLiteral{Token: varTok, Value: 0}
-	}
-
 	return &ast.AssignStmt{
 		Token: varTok,
 		Left:  lefts,
-		Right: rights,
+		Right: nil,
 		Type:  typeExpr,
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #2. Supersedes and resolves the underlying root cause behind #3.

This PR fixes a compiler panic encountered when declaring uninitialized fixed-size arrays (e.g., `var h [5]int`). Rather than permitting invalid scalar-to-aggregate casts in the code generator, this change eliminates synthetic dummy literals in the parser and correctly lowers uninitialized variables to LLVM `zeroinitializer` stores.

---

## Root Cause Analysis

PR #3 attempted to resolve the panic `[Emitter Panic] invalid cast operation: cannot cast 'i64' to '[5 x i64]'` by introducing array aggregate handling (`insertvalue` / `extractvalue`) directly into `Emitter.emitCast`.

While this allowed the reproduction code to execute, it addressed a symptom rather than the architectural root cause. In Hike (as in Go), implicit casts between scalar values and aggregate arrays are fundamentally invalid and violate type safety. Allowing scalar-to-aggregate coercions in `emitCast` compromises the type system.

Tracing the origin of `(val: 0, dst: %v3)` revealed the real defects:

1. **Synthetic Literal Fabrication in Parser (`pkg/parser/parser.go`)**:
In `parseVarStmt`, when a local variable declaration omitted an explicit initial value (e.g., `var h [5]int`), the parser synthesized dummy integer zero expressions:
```go
rights := make([]ast.Expression, len(idents))
for i := range rights {
    rights[i] = &ast.IntegerLiteral{Token: varTok, Value: 0}
}

```


This turned an uninitialized variable declaration into a synthetic assignment of scalar integer `0` to the target variable.
2. **Invalid Coercion during Lowering (`pkg/lower/lower_stmt.go`)**:
In `LowerAssignStmt`, because `rhsVals` contained the synthetic integer literal `0`, the compiler attempted to coerce the scalar `0` into the target array type `[5 x i64]` via `emitValueCoerce`. This emitted an invalid HIR instruction (`%v = cast i64 0 to [5 x i64]`), which inevitably panicked in `Emitter.emitCast`.

PR #3 appeared to work only because the inserted scalar happened to be the synthetic `0`. Inserting `0` into element index 0 of `zeroinitializer` produced an all-zero array by coincidence, masking the true problem.

---

## Solution & Implementation

This PR addresses the issue cleanly across the frontend and lowering stages without touching or polluting `Emitter.emitCast`:

1. **Preserve Omitted RHS in Parser (`pkg/parser/parser.go`)**:
Modified `parseVarStmt` so that uninitialized declarations leave `Right` as `nil` instead of synthesizing `IntegerLiteral{Value: 0}`.
2. **Type-Driven Default Zero Values in Lowering (`pkg/lower/lower_stmt.go`)**:
In `LowerAssignStmt` (under the `isDefine` branch), when a variable is declared with an explicit type (`stmt.Type != nil`) but without an initial value (`val == nil`), the compiler queries `s.root.defaultConstValue(targetType)`.
For array types (`*sema.ArrayType`), `defaultConstValue` returns `&hir.ConstZero{Typ: targetType}`, which represents LLVM's `zeroinitializer`.
3. **Optimal LLVM IR Output**:
The lowering stage now directly issues a typed zero-initialization store:
```llvm
%h.3 = alloca [5 x i64]
store [5 x i64] zeroinitializer, [5 x i64]* %h.3

```


No intermediary casts or synthetic instructions are generated.

---

## Verification

Compiled `examples/shared/libcalc.hike` containing `CTestArr`:

```hike
cfunc CTestArr(val int) int {
    var h [5]int
    h[0] = val
    h[1] = val + 1
    var sum int = 0
    sum = h[0] + h[1]
    return sum
}

```

* **Compilation**: Succeeded with zero warnings or panics.
* **IR Inspection**: Verified that `%h.3` receives `store [5 x i64] zeroinitializer, [5 x i64]* %h.3` immediately after allocation.
* **Header Generation**: Verified `libcalc.h` correctly exports `HIKE_API int64_t CTestArr(int64_t val);`.